### PR TITLE
feat: add basic Makefile validation

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,3 +6,11 @@
   types: [file]
   files: '^Makefile$'
   args: []
+- id: makefile-validator
+  name: makefile-validator
+  description: Validate Makefile
+  entry: pre-commit-makefile validate
+  language: system
+  types: [file]
+  files: '^Makefile$'
+  args: []

--- a/README.md
+++ b/README.md
@@ -48,8 +48,17 @@ repos:
   - repo: https://github.com/shini4i/pre-commit-makefile
     rev: v0.1.6
     hooks:
+      - id: makefile-validator
       - id: makefile-readme-updater
 ```
+
+## Validator
+
+Currently, the validator is limited to checking if the `Makefile` targets have relevant `.PHONY` definitions.
+
+No additional configuration is required.
+
+## Readme Updater
 
 The following comment markers should be added to your `README.md`:
 
@@ -68,7 +77,7 @@ args:
   - --section-name=## Usage
 ```
 
-## Example
+#### Example
 The `Makefile` in this repository will produce the following output:
 
 To install dependencies run:

--- a/cmd/pre-commit-makefile/cli.go
+++ b/cmd/pre-commit-makefile/cli.go
@@ -9,12 +9,8 @@ import (
 
 const version = "0.1.6"
 
-func cli() error {
-	var readmePath string
-	var sectionName string
-	var printVersion bool
-
-	var cmdRun = &cobra.Command{
+func runCommand(readmePath *string, sectionName *string) *cobra.Command {
+	return &cobra.Command{
 		Use:   "run",
 		Short: "Run the pre-commit-makefile",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -22,50 +18,62 @@ func cli() error {
 				Fs: afero.NewOsFs(),
 			}
 
-			if err := app.Run(readmePath, sectionName); err != nil {
+			if err := app.Run(*readmePath, *sectionName); err != nil {
 				return err
 			}
 
 			return nil
 		},
 	}
+}
 
-	var cmdValidate = &cobra.Command{
+func validateCommand() *cobra.Command {
+	return &cobra.Command{
 		Use:   "validate",
 		Short: "Validate the pre-commit-makefile",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			fmt.Println("Validating Makefile")
 			if err := ValidateMakefile(afero.NewOsFs(), "Makefile"); err != nil {
 				return err
 			}
 			return nil
 		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
+}
 
-	cmdRun.Flags().StringVarP(&readmePath, "readme-path", "r", "README.md", "Path to the readme file")
-	cmdRun.Flags().StringVarP(&sectionName, "section-name", "s", "## Makefile targets", "Readme section name to put the description in")
-
-	var rootCmd = &cobra.Command{
+func rootCommand(printVersion *bool) *cobra.Command {
+	cmd := &cobra.Command{
 		Use: "pre-commit-makefile",
 		Run: func(cmd *cobra.Command, args []string) {
-			if printVersion {
+			if *printVersion {
 				fmt.Println(version)
 				return
 			}
 
 			// Else: Display default help
 			if err := cmd.Help(); err != nil {
-				return
+				fmt.Println(err)
 			}
 		},
 	}
 
-	rootCmd.PersistentFlags().BoolVarP(&printVersion, "version", "v", false, "Print version and exit")
-	rootCmd.AddCommand(cmdRun)
-	rootCmd.AddCommand(cmdValidate)
+	cmd.PersistentFlags().BoolVarP(printVersion, "version", "v", false, "Print version and exit")
+	return cmd
+}
 
-	if err := rootCmd.Execute(); err != nil {
-		return err
-	}
-	return nil
+func cli() error {
+	var readmePath string
+	var sectionName string
+	var printVersion bool
+
+	cmdRun := runCommand(&readmePath, &sectionName)
+	cmdRun.Flags().StringVarP(&readmePath, "readme-path", "r", "README.md", "Path to the readme file")
+	cmdRun.Flags().StringVarP(&sectionName, "section-name", "s", "## Makefile targets", "Readme section name to put the description in")
+
+	rootCmd := rootCommand(&printVersion)
+	rootCmd.AddCommand(cmdRun)
+	rootCmd.AddCommand(validateCommand())
+
+	return rootCmd.Execute()
 }

--- a/cmd/pre-commit-makefile/cli.go
+++ b/cmd/pre-commit-makefile/cli.go
@@ -30,6 +30,18 @@ func cli() error {
 		},
 	}
 
+	var cmdValidate = &cobra.Command{
+		Use:   "validate",
+		Short: "Validate the pre-commit-makefile",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Println("Validating Makefile")
+			if err := ValidateMakefile(afero.NewOsFs(), "Makefile"); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+
 	cmdRun.Flags().StringVarP(&readmePath, "readme-path", "r", "README.md", "Path to the readme file")
 	cmdRun.Flags().StringVarP(&sectionName, "section-name", "s", "## Makefile targets", "Readme section name to put the description in")
 
@@ -50,6 +62,7 @@ func cli() error {
 
 	rootCmd.PersistentFlags().BoolVarP(&printVersion, "version", "v", false, "Print version and exit")
 	rootCmd.AddCommand(cmdRun)
+	rootCmd.AddCommand(cmdValidate)
 
 	if err := rootCmd.Execute(); err != nil {
 		return err

--- a/cmd/pre-commit-makefile/validator.go
+++ b/cmd/pre-commit-makefile/validator.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/afero"
+)
+
+func ValidateMakefile(fs afero.Fs, makefilePath string) error {
+	file, err := fs.Open(makefilePath)
+	if err != nil {
+		return fmt.Errorf("error opening Makefile: %s", err)
+	}
+	defer file.Close()
+
+	targetRegex := regexp.MustCompile(`^([a-zA-Z._-]+):`)
+	phonyRegex := regexp.MustCompile(`^\.PHONY: (.*)$`)
+
+	var targets []string
+	var phonies []string
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		targetMatches := targetRegex.FindStringSubmatch(line)
+		phonyMatches := phonyRegex.FindStringSubmatch(line)
+
+		if len(targetMatches) == 2 && !strings.HasPrefix(line, ".PHONY:") {
+			targets = append(targets, targetMatches[1])
+		}
+
+		if len(phonyMatches) == 2 {
+			phonies = append(phonies, phonyMatches[1])
+		}
+	}
+
+	fmt.Println(targets)
+	fmt.Println(phonies)
+	for _, target := range targets {
+		found := false
+		for _, phony := range phonies {
+			if target == phony {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("target '%s' does not have a corresponding .PHONY definition", target)
+		}
+	}
+
+	return nil
+}

--- a/cmd/pre-commit-makefile/validator_test.go
+++ b/cmd/pre-commit-makefile/validator_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateMakefile(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	testMakefilePath := "/test/Makefile"
+
+	// Creating a fake Makefile
+	makefileContent := `
+.PHONY: start-server
+start-server:
+
+.PHONY: test-build
+test-build:
+`
+
+	if err := afero.WriteFile(fs, testMakefilePath, []byte(makefileContent), 0644); err != nil {
+		t.Fatalf("error writing Makefile: %v", err)
+	}
+
+	assert.NoError(t, ValidateMakefile(fs, testMakefilePath))
+
+	// Creating a fake Makefile with a target without a .PHONY definition
+	makefileContent = `
+.PHONY: start-server
+start-server:
+
+
+test-build:`
+
+	if err := afero.WriteFile(fs, testMakefilePath, []byte(makefileContent), 0644); err != nil {
+		t.Fatalf("error writing Makefile: %v", err)
+	}
+
+	assert.Error(t, ValidateMakefile(fs, testMakefilePath))
+}

--- a/cmd/pre-commit-makefile/validator_test.go
+++ b/cmd/pre-commit-makefile/validator_test.go
@@ -32,7 +32,6 @@ test-build:
 .PHONY: start-server
 start-server:
 
-
 test-build:`
 
 	if err := afero.WriteFile(fs, testMakefilePath, []byte(makefileContent), 0644); err != nil {


### PR DESCRIPTION
A first step towards the goal stated in #9.

Currently, we only validate that all targets have corresponding .PHONY